### PR TITLE
Bug 513782 - Fixes #26: Add DndTabPane

### DIFF
--- a/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
+++ b/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
@@ -19,6 +19,7 @@ import org.eclipse.fx.ui.controls.tabpane.DndTabPaneFactory.DragSetup;
 import org.eclipse.fx.ui.controls.tabpane.DndTabPaneFactory.FeedbackType;
 import org.eclipse.fx.ui.controls.tabpane.skin.DnDTabPaneSkinHookerFullDrag;
 import org.eclipse.fx.ui.controls.tabpane.skin.DndTabPaneSkinHooker;
+import org.eclipse.jdt.annotation.Nullable;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -33,8 +34,8 @@ import javafx.scene.control.TabPane;
  */
 public class DndTabPane extends TabPane {
 	private static final FeedbackType DEFAULT_FEEDBACK_TYPE = FeedbackType.MARKER;
-	private final BooleanProperty allowDetach = new SimpleBooleanProperty(this, "allowDetach"); //$NON-NLS-1$
-	private final ObjectProperty<FeedbackType> feedbackType = new SimpleObjectProperty<>(this, "feedbackType", DEFAULT_FEEDBACK_TYPE); //$NON-NLS-1$
+	private @Nullable BooleanProperty allowDetach;
+	private @Nullable ObjectProperty<FeedbackType> feedbackType;
 
 	private DragSetup setup;
 
@@ -56,7 +57,7 @@ public class DndTabPane extends TabPane {
 	public DndTabPane(FeedbackType feedbackType, boolean allowDetach) {
 		setFeedbackType(feedbackType);
 		setAllowDetach(allowDetach);
-		initListeners(setup -> setup(this.feedbackType::get, this, getChildren(), setup, null));
+		initListeners(setup -> setup(feedbackTypeProperty()::get, this, getChildren(), setup, null));
 	}
 
 	/**
@@ -96,7 +97,7 @@ public class DndTabPane extends TabPane {
 				setupDnd(newValue, setup);
 			}
 		});
-		this.allowDetach.addListener((observable, oldValue, newValue) -> {
+		allowDetachProperty().addListener((observable, oldValue, newValue) -> {
 			if (newValue != null) {
 				Skin<?> skin = getSkin();
 				if (skin != null) {
@@ -122,6 +123,9 @@ public class DndTabPane extends TabPane {
 	 * @return a property indicating whether Tabs can be detached or not
 	 */
 	public BooleanProperty allowDetachProperty() {
+		if (this.allowDetach == null) {
+			this.allowDetach = new SimpleBooleanProperty(this, "allowDetach"); //$NON-NLS-1$
+		}
 		return this.allowDetach;
 	}
 
@@ -129,7 +133,7 @@ public class DndTabPane extends TabPane {
 	 * @return whether Tabs can be detached or not
 	 */
 	public boolean isAllowDetach() {
-		return this.allowDetach.get();
+		return this.allowDetach != null ? this.allowDetach.get() : false;
 	}
 
 	/**
@@ -137,13 +141,16 @@ public class DndTabPane extends TabPane {
 	 *            whether Tabs can be detached or not
 	 */
 	public void setAllowDetach(boolean allowDetach) {
-		this.allowDetach.set(allowDetach);
+		allowDetachProperty().set(allowDetach);
 	}
 
 	/**
 	 * @return the type of visual Feedback for the User
 	 */
 	public ObjectProperty<FeedbackType> feedbackTypeProperty() {
+		if (this.feedbackType == null) {
+			this.feedbackType = new SimpleObjectProperty<>(this, "feedbackType", DEFAULT_FEEDBACK_TYPE); //$NON-NLS-1$
+		}
 		return this.feedbackType;
 	}
 
@@ -151,7 +158,7 @@ public class DndTabPane extends TabPane {
 	 * @return the type of visual Feedback for the User
 	 */
 	public FeedbackType getFeedbackType() {
-		return this.feedbackType.get();
+		return this.feedbackType != null ? this.feedbackType.get() : DEFAULT_FEEDBACK_TYPE;
 	}
 
 	/**
@@ -159,6 +166,6 @@ public class DndTabPane extends TabPane {
 	 *            the type of visual Feedback for the User
 	 */
 	public void setFeedbackType(FeedbackType feedbackType) {
-		this.feedbackType.set(feedbackType);
+		feedbackTypeProperty().set(feedbackType);
 	}
 }

--- a/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
+++ b/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
@@ -92,6 +92,9 @@ public class DndTabPane extends TabPane {
 			if (newValue != null) {
 				Skin<?> skin = getSkin();
 				if (skin != null) {
+					if (this.setup != null) {
+						teardown(this.setup);
+					}
 					setupDnd(skin, setup);
 				}
 			}

--- a/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
+++ b/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
@@ -33,8 +33,8 @@ import javafx.scene.control.TabPane;
  */
 public class DndTabPane extends TabPane {
 	private static final FeedbackType DEFAULT_FEEDBACK_TYPE = FeedbackType.MARKER;
-	private final BooleanProperty allowDetach = new SimpleBooleanProperty();
-	private final ObjectProperty<FeedbackType> feedbackType = new SimpleObjectProperty<>(DEFAULT_FEEDBACK_TYPE);
+	private final BooleanProperty allowDetach = new SimpleBooleanProperty(this, "allowDetach"); //$NON-NLS-1$
+	private final ObjectProperty<FeedbackType> feedbackType = new SimpleObjectProperty<>(this, "feedbackType", DEFAULT_FEEDBACK_TYPE); //$NON-NLS-1$
 
 	private DragSetup setup;
 

--- a/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
+++ b/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
@@ -31,6 +31,8 @@ import javafx.scene.control.TabPane;
 
 /**
  * A TabPane with Drag and Drop Support
+ *
+ * @since 3.0.0
  */
 public class DndTabPane extends TabPane {
 	private static final FeedbackType DEFAULT_FEEDBACK_TYPE = FeedbackType.MARKER;

--- a/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
+++ b/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
@@ -1,0 +1,153 @@
+package org.eclipse.fx.ui.controls.tabpane;
+
+import static org.eclipse.fx.ui.controls.tabpane.DndTabPaneFactory.setup;
+import static org.eclipse.fx.ui.controls.tabpane.DndTabPaneFactory.teardown;
+
+import java.util.function.Consumer;
+
+import org.eclipse.fx.ui.controls.tabpane.DndTabPaneFactory.DragSetup;
+import org.eclipse.fx.ui.controls.tabpane.DndTabPaneFactory.FeedbackType;
+import org.eclipse.fx.ui.controls.tabpane.skin.DnDTabPaneSkinHookerFullDrag;
+import org.eclipse.fx.ui.controls.tabpane.skin.DndTabPaneSkinHooker;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.control.Skin;
+import javafx.scene.control.SkinBase;
+import javafx.scene.control.TabPane;
+
+/**
+ * A TabPane with Drag and Drop Support
+ *
+ * @author Adrodoc55
+ */
+public class DndTabPane extends TabPane {
+	private static final FeedbackType DEFAULT_FEEDBACK_TYPE = FeedbackType.MARKER;
+	private final BooleanProperty allowDetach = new SimpleBooleanProperty();
+	private final ObjectProperty<FeedbackType> feedbackType = new SimpleObjectProperty<>(DEFAULT_FEEDBACK_TYPE);
+
+	private DragSetup setup;
+
+	/**
+	 * Create a tab pane with a default setup for Drag and Drop Feedback
+	 */
+	public DndTabPane() {
+		this(DEFAULT_FEEDBACK_TYPE, false);
+	}
+
+	/**
+	 * Create a tab pane with a default setup for Drag and Drop Feedback
+	 *
+	 * @param feedbackType
+	 *            the feedback type
+	 * @param allowDetach
+	 *            allow detaching
+	 */
+	public DndTabPane(FeedbackType feedbackType, boolean allowDetach) {
+		setFeedbackType(feedbackType);
+		setAllowDetach(allowDetach);
+		initListeners(setup -> setup(this.feedbackType::get, this, getChildren(), setup, null));
+	}
+
+	/**
+	 * Create a tab pane and set the drag strategy
+	 *
+	 * @param allowDetach
+	 *            allow detaching
+	 * @param setup
+	 *            the setup instance for the pane
+	 */
+	public DndTabPane(boolean allowDetach, Consumer<DragSetup> setup) {
+		this(DEFAULT_FEEDBACK_TYPE, allowDetach, setup);
+	}
+
+	/**
+	 * Create a tab pane and set the drag strategy
+	 *
+	 * @param feedbackType
+	 *            the feedback type
+	 * @param allowDetach
+	 *            allow detaching
+	 * @param setup
+	 *            the setup instance for the pane
+	 */
+	public DndTabPane(FeedbackType feedbackType, boolean allowDetach, Consumer<DragSetup> setup) {
+		setFeedbackType(feedbackType);
+		setAllowDetach(allowDetach);
+		initListeners(setup);
+	}
+
+	private void initListeners(Consumer<DragSetup> setup) {
+		skinProperty().addListener((observable, oldValue, newValue) -> {
+			if (oldValue != null && this.setup != null) {
+				teardown(this.setup);
+			}
+			if (newValue != null) {
+				setupDnd(newValue, setup);
+			}
+		});
+		this.allowDetach.addListener((observable, oldValue, newValue) -> {
+			if (newValue != null) {
+				Skin<?> skin = getSkin();
+				if (skin != null) {
+					setupDnd(skin, setup);
+				}
+			}
+		});
+	}
+
+	private void setupDnd(Skin<?> skin, Consumer<DragSetup> setup) {
+		if (isAllowDetach()) {
+			this.setup = new DnDTabPaneSkinHookerFullDrag((SkinBase<TabPane>) skin);
+		} else {
+			this.setup = new DndTabPaneSkinHooker((Skin<TabPane>) skin);
+		}
+		setup.accept(this.setup);
+	}
+
+	/**
+	 * @return a property indicating whether Tabs can be detached or not
+	 */
+	public BooleanProperty allowDetachProperty() {
+		return this.allowDetach;
+	}
+
+	/**
+	 * @return whether Tabs can be detached or not
+	 */
+	public boolean isAllowDetach() {
+		return this.allowDetach.get();
+	}
+
+	/**
+	 * @param allowDetach
+	 *            whether Tabs can be detached or not
+	 */
+	public void setAllowDetach(boolean allowDetach) {
+		this.allowDetach.set(allowDetach);
+	}
+
+	/**
+	 * @return the type of visual Feedback for the User
+	 */
+	public ObjectProperty<FeedbackType> feedbackTypeProperty() {
+		return this.feedbackType;
+	}
+
+	/**
+	 * @return the type of visual Feedback for the User
+	 */
+	public FeedbackType getFeedbackType() {
+		return this.feedbackType.get();
+	}
+
+	/**
+	 * @param feedbackType
+	 *            the type of visual Feedback for the User
+	 */
+	public void setFeedbackType(FeedbackType feedbackType) {
+		this.feedbackType.set(feedbackType);
+	}
+}

--- a/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
+++ b/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/DndTabPane.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2014 BestSolution.at and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Adrodoc55<adrodoc55@googlemail.com> - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.fx.ui.controls.tabpane;
 
 import static org.eclipse.fx.ui.controls.tabpane.DndTabPaneFactory.setup;
@@ -20,8 +30,6 @@ import javafx.scene.control.TabPane;
 
 /**
  * A TabPane with Drag and Drop Support
- *
- * @author Adrodoc55
  */
 public class DndTabPane extends TabPane {
 	private static final FeedbackType DEFAULT_FEEDBACK_TYPE = FeedbackType.MARKER;


### PR DESCRIPTION
This change adds the class DndTabPane which can be used in a fxml file unlike the existing DndTabPaneFactory and changes the DndTabPaneFactory in order to reuse the code.

Something that might still be an issue is the teardown of an old DragSetup. The teardown method removes all listeners of the setup method, but it does not remove any listeners that were registered in the constructor or the DragSetup, for instance [DndTabPaneSkinHooker](https://github.com/eclipse/efxclipse-rt/blob/master/bundles/runtime/org.eclipse.fx.ui.controls/src/org/eclipse/fx/ui/controls/tabpane/skin/DndTabPaneSkinHooker.java#L88-L116).
It is propably a good idea to add a method teardown or dispose to the interface DragSetup and remove all other listeners there, but i am not sure if this would be the correct way.

This is not that big of a problem though, because it only applies if a programmer changes the skin or allowDetach multiple times, which is not the case when using fxml and pretty unlikely when using the factory.