### PR TITLE
Implement the base field editors, as well as Apply/Restore defaults

### DIFF
--- a/demos/org.eclipse.fx.ui.preferences.app/src/org/eclipse/fx/ui/preferences/app/pages/PreferencePageProvider_1.java
+++ b/demos/org.eclipse.fx.ui.preferences.app/src/org/eclipse/fx/ui/preferences/app/pages/PreferencePageProvider_1.java
@@ -2,13 +2,17 @@ package org.eclipse.fx.ui.preferences.app.pages;
 
 import java.util.Optional;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.eclipse.fx.core.Memento;
 import org.eclipse.fx.ui.preferences.PreferencePage;
 import org.eclipse.fx.ui.preferences.PreferencePageProvider;
+import org.eclipse.fx.ui.preferences.page.BooleanFieldEditor;
+import org.eclipse.fx.ui.preferences.page.ColorFieldEditor;
+import org.eclipse.fx.ui.preferences.page.DirectoryFieldEditor;
 import org.eclipse.fx.ui.preferences.page.FieldEditorPreferencePage;
+import org.eclipse.fx.ui.preferences.page.IntegerFieldEditor;
+import org.eclipse.fx.ui.preferences.page.TextFieldEditor;
 import org.osgi.service.component.annotations.Component;
 
 import javafx.beans.property.ObjectProperty;
@@ -51,9 +55,13 @@ public class PreferencePageProvider_1 implements PreferencePageProvider {
 			super(memento, parent);
 		}
 		
-		@PostConstruct
-		void init() {
-			System.err.println("CREATED");
+		@Override
+		protected void createFieldEditors() {
+			addField(new BooleanFieldEditor("booleanProperty", "Boolean Property"));
+			addField(new IntegerFieldEditor("integerProperty", "Integer Property"));
+			addField(new ColorFieldEditor("colorProperty", "Color Property"));
+			addField(new DirectoryFieldEditor("directoryProperty", "Directory Property"));
+			addField(new TextFieldEditor("textProperty", "Text"));
 		}
 	}
 }

--- a/modules/ui/org.eclipse.fx.ui.preferences/META-INF/MANIFEST.MF
+++ b/modules/ui/org.eclipse.fx.ui.preferences/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Import-Package: javax.inject;version="1.0.0",
  org.eclipse.fx.core.command;version="3.2.0",
  org.eclipse.fx.core.di;version="3.2.0",
  org.eclipse.fx.core.observable;version="3.2.0",
+ org.eclipse.fx.ui.controls.form;version="3.2.0",
  org.eclipse.fx.ui.controls.list;version="3.2.0"
 Export-Package: org.eclipse.fx.ui.preferences,
  org.eclipse.fx.ui.preferences.page

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/PreferenceUI.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/PreferenceUI.java
@@ -53,6 +53,7 @@ public class PreferenceUI {
 		this.factory = factory;
 		this.providerView = new ListView<>();
 		this.contentArea = new ScrollPane();
+		this.contentArea.setFitToWidth(true);
 		
 		this.providerView.setCellFactory( v -> new SimpleListCell<>( pp -> pp.titleProperty().getValue()));
 		FXObservableUtil.onChange(this.providerView.getSelectionModel().selectedItemProperty(), this::handleSelectedPageChange);
@@ -94,8 +95,15 @@ public class PreferenceUI {
 		split.setDividerPositions(0.3);
 		
 		root.setCenter(split);
+		
+		selectFirstPage();
 	}
 	
+	private void selectFirstPage() {
+		providerView.getSelectionModel().clearSelection();
+		providerView.getSelectionModel().selectFirst();
+	}
+
 	@Inject
 	public void setPreferencePageProviders(@Service List<PreferencePageProvider> providers) {
 		providerView.getItems().setAll(providers);

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/ColorFieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/ColorFieldEditor.java
@@ -1,22 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2018 BestSolution.at, EclipseSource and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Tom Schindl<tom.schindl@bestsolution.at> - initial API
+ *     Camille Letavernier <cletavernier@eclipsesource.com> - initial implementation
+ *******************************************************************************/
 package org.eclipse.fx.ui.preferences.page;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javafx.scene.control.ColorPicker;
+import javafx.scene.paint.Color;
+
+/**
+ * <p>A Field editor for color preferences.</p>
+ */
 public class ColorFieldEditor extends FieldEditor {
 
+	private final ColorPicker colorPicker;
+	
+	public ColorFieldEditor(String name, String label) {
+		super(name, label);
+		this.colorPicker = new ColorPicker();
+		getChildren().add(colorPicker);
+	}
+	
 	public ColorFieldEditor(String name) {
-		super(name);
-		// TODO Auto-generated constructor stub
+		this(name, null);
 	}
 
 	@Override
 	void load() {
-		// TODO Auto-generated method stub
-		
+		String color = getMemento().get(getName(), "0;0;0;1");
+		this.colorPicker.setValue(parseColor(color));
+	}
+
+	/** RGBA Format: 255;255;255;1.0 */
+	private static Pattern colorRegex = Pattern.compile("(\\d{1,3});(\\d{1,3});(\\d{1,3});(\\d(\\.\\d+)?)");
+	
+	private Color parseColor(String color) {
+		Matcher matcher = colorRegex.matcher(color);
+		if (matcher.matches()) {
+			String red = matcher.group(1);
+			String green = matcher.group(2);
+			String blue = matcher.group(3);
+			String alpha = matcher.group(4);
+			try {
+				int r = Integer.parseInt(red);
+				int g = Integer.parseInt(green);
+				int b = Integer.parseInt(blue);
+				double a = Double.parseDouble(alpha);
+				return new Color(toDouble(r), toDouble(g), toDouble(b), a); //Will throw if the values are out of range
+			} catch (Exception ex) {
+				ex.printStackTrace(); //TODO Log
+				return Color.BLACK;
+			}
+		}
+		return null;
+	}
+
+	private static double toDouble(int intColor) {
+		return intColor/255.;
 	}
 
 	@Override
 	void persist() {
-		// TODO Auto-generated method stub
-		
+		Color color = this.colorPicker.getValue();
+		getMemento().put(getName(), toString(color));
 	}
+	
+	private static String toString(Color color) {
+		return String.format("%s;%s;%s;%s", toInt(color.getRed()), toInt(color.getGreen()), toInt(color.getBlue()), color.getOpacity());
+	}
+
+	private static int toInt(double color) {
+		return (int)Math.round(color*255);
+	}
+	
+	
 
 }

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/DirectoryFieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/DirectoryFieldEditor.java
@@ -1,22 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2018 BestSolution.at, EclipseSource and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Tom Schindl<tom.schindl@bestsolution.at> - initial API
+ *     Camille Letavernier <cletavernier@eclipsesource.com> - initial implementation
+ *******************************************************************************/
 package org.eclipse.fx.ui.preferences.page;
 
-public class DirectoryFieldEditor extends FieldEditor {
+import java.io.File;
+
+import javafx.scene.control.Button;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.Window;
+
+/**
+ * <p>A Field editor for directories.</p>
+ */
+public class DirectoryFieldEditor extends TextFieldEditor {
+
+	public DirectoryFieldEditor(String name, String label) {
+		super(name, label);
+		Button browse = new Button("...");
+		getTextContainer().getChildren().add(browse);
+		browse.setOnAction(event -> browse(browse.getScene().getWindow()));
+	}
+	
+	private void browse(Window parent) {
+		DirectoryChooser chooser = new DirectoryChooser();
+		chooser.setInitialDirectory(getCurrentFolder());
+		File result = chooser.showDialog(parent);
+		if (result != null) {
+			setCurrentFolder(result);
+		}
+	}
+
+	private void setCurrentFolder(File result) {
+		getTextField().setText(result.getPath());
+	}
+
+	private File getCurrentFolder() {
+		String textValue = getTextField().getText();
+		File folder = new File(textValue);
+		//Find the first existing folder in the current path hierarchy
+		while (folder != null && ! folder.isDirectory()) {
+			folder = folder.getParentFile();
+		}
+		return folder;
+	}
 
 	public DirectoryFieldEditor(String name) {
-		super(name);
-		// TODO Auto-generated constructor stub
-	}
-
-	@Override
-	void load() {
-		// TODO Auto-generated method stub
-		
-	}
-
-	@Override
-	void persist() {
-		// TODO Auto-generated method stub
-		
+		this(name, null);
 	}
 
 }

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/FieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/FieldEditor.java
@@ -11,12 +11,25 @@ public abstract class FieldEditor<T> extends Region {
 	private String name;
 	private Memento memento;
 	
-	public FieldEditor(String name) {
+	public FieldEditor(String name, String label) {
 		this.name = name;
+		this.setLabel(label);
+	}
+	
+	public FieldEditor(String name) {
+		this(name, null);
 	}
 	
 	void setMemento(Memento memento) {
 		this.memento = memento;
+	}
+	
+	protected Memento getMemento() {
+		return this.memento;
+	}
+	
+	protected String getName() {
+		return this.name;
 	}
 	
 	abstract void load();

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/FieldEditorPreferencePage.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/FieldEditorPreferencePage.java
@@ -4,43 +4,95 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.PostConstruct;
+
 import org.eclipse.fx.core.Memento;
 import org.eclipse.fx.core.command.Command;
 
+import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
 
 public abstract class FieldEditorPreferencePage extends BasePreferencePage {
 	private BorderPane parent;
 	private GridPane grid = new GridPane();
+	private HBox actions = new HBox();
 	private List<FieldEditor<?>> editors = new ArrayList<>();
 	
 	public FieldEditorPreferencePage(Memento memento, BorderPane parent) {
 		super(memento);
 		this.parent = parent;
-		this.parent.setCenter(new Button("hello"));
+		this.parent.setCenter(grid);
+		this.parent.setBottom(actions);
+		actions.setAlignment(Pos.BASELINE_RIGHT);
 	}
 
 	@Override
 	public Command<Void> persist() {
-		// TODO Auto-generated method stub
-		return null;
+		return Command.createCommand(() -> editors.forEach(FieldEditor::persist));
 	}
 	
 	@Override
 	public Optional<Command<Void>> restoreDefault() {
-		// TODO Auto-generated method stub
-		return null;
+		//XXX Should we rely on the Memento to get the default values,
+		//or should the specific page instance be responsible for that?
+		//Currently, we rely on the Memento
+		//XXX In JFace, it seems that "restore defaults" simply pushes
+		//new values to the FieldEditor, without actually persisting them.
+		//Pressing Restore Default then Cancel doesn't change the persisted values
+		//The user actually needs to press update to force the changes
+		//Do we want the same behavior here?
+		return Optional.of(Command.createCommand(() -> {
+			for (FieldEditor<?> fieldEditor : editors) {
+				FieldEditorPreferencePage.this.memento.remove(fieldEditor.getName());
+			}
+			doReset();
+		}));
 	}
 	
-	@Override
-	public Command<Void> reset() {
-		// TODO Auto-generated method stub
-		return null;
+	@PostConstruct
+	void initFieldEditors() {
+		createActionButtons();
+		createFieldEditors();
+		reset().execute();
+	}
+	
+	abstract protected void createFieldEditors();
+	
+	protected void createActionButtons() {
+		addButton("Restore Defaults", this.restoreDefault());
+		addButton("Apply", Optional.of(this.persist()));
+	}
+	
+	protected void addButton(String label, Optional<Command<Void>> restoreDefault) {
+		Button action = new Button(label);
+		actions.getChildren().add(action);
+		if (restoreDefault.isPresent()) {
+			Command<Void> command = restoreDefault.get();
+			action.disableProperty().bind(command.enabledProperty().not());
+			action.setOnAction(event -> {
+				command.evaluate();
+				if (command.isEnabled()) {
+					command.execute();
+				}
+			});
+		} else {
+			action.setDisable(true);
+		}
 	}
 
+	@Override
+	public Command<Void> reset() {
+		return Command.createCommand(this::doReset);
+	}
+	
+	void doReset() {
+		this.editors.forEach(FieldEditor::load);
+	}
+	
 	public void addField(FieldEditor<?> editor) {
 		Label l = new Label();
 		l.textProperty().bind(editor.labelProperty());

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/IntegerFieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/IntegerFieldEditor.java
@@ -1,22 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2018 BestSolution.at, EclipseSource and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Tom Schindl<tom.schindl@bestsolution.at> - initial API
+ *     Camille Letavernier <cletavernier@eclipsesource.com> - initial implementation
+ *******************************************************************************/
 package org.eclipse.fx.ui.preferences.page;
 
+import org.eclipse.fx.core.Status;
+import org.eclipse.fx.core.Status.State;
+import org.eclipse.fx.ui.controls.form.NodeDecorator;
+
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.control.TextField;
+
+/**
+ * <p>A Field editor for integer preferences.</p>
+ */
 public class IntegerFieldEditor extends FieldEditor {
 
+	private final TextField textField;
+
+	public IntegerFieldEditor(String name, String label) {
+		super(name, label);
+		this.textField = new TextField();
+		getChildren().add(textField);
+		
+		configureValidation(this.textField);
+	}
+	
+	private void configureValidation(TextField textField) {
+		SimpleObjectProperty<Status> status = new SimpleObjectProperty<Status>(Status.ok());
+		NodeDecorator.apply(this.textField, status);
+		this.textField.textProperty().addListener((obs, oldText, newText) -> {
+			try {
+				Integer.parseInt(newText);
+				status.set(Status.ok());
+			} catch (NumberFormatException ex) {
+				status.set(Status.status(State.ERROR, Status.UNKNOWN_RETURN_CODE, "The value must be a valid integer", ex));
+			}
+		});
+	}
+
 	public IntegerFieldEditor(String name) {
-		super(name);
-		// TODO Auto-generated constructor stub
+		this(name, null);
 	}
 
 	@Override
 	void load() {
-		// TODO Auto-generated method stub
-		
+		this.textField.setText(Integer.toString(getMemento().get(getName(), 0)));
 	}
 
 	@Override
 	void persist() {
-		// TODO Auto-generated method stub
-		
+		try {
+			getMemento().put(getName(), getIntValue());
+		} catch (NumberFormatException ex) {
+			//Don't persist when the current value is incorrect
+			ex.printStackTrace(); //TODO Log
+		}
+	}
+
+	private int getIntValue() throws NumberFormatException {
+		return Integer.parseInt(textField.getText());
 	}
 
 }

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/TextFieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/TextFieldEditor.java
@@ -11,33 +11,45 @@
  *******************************************************************************/
 package org.eclipse.fx.ui.preferences.page;
 
-import javafx.scene.control.CheckBox;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
 
 /**
- * <p>A Field editor for boolean preferences.</p>
+ * <p>A Field editor for string preferences.</p>
  */
-public class BooleanFieldEditor extends FieldEditor {
+public class TextFieldEditor extends FieldEditor {
 
-	private final CheckBox checkBox;
-
-	public BooleanFieldEditor(String name, String label) {
+	private HBox textFieldContainer;
+	private TextField textField;
+	
+	public TextFieldEditor(String name, String label) {
 		super(name, label);
-		this.checkBox = new CheckBox();
-		getChildren().add(checkBox);
+		this.textFieldContainer = new HBox();
+		this.textField = new TextField();
+		this.textFieldContainer.getChildren().add(textField);
+		getChildren().add(this.textFieldContainer);
 	}
 	
-	public BooleanFieldEditor(String name) {
-		this(name, null);		
+	protected HBox getTextContainer() {
+		return this.textFieldContainer;
+	}
+	
+	protected TextField getTextField() {
+		return this.textField;
+	}
+
+	public TextFieldEditor(String name) {
+		this(name, null);
 	}
 
 	@Override
 	void load() {
-		this.checkBox.setSelected(getMemento().get(getName(), false));
+		this.textField.setText(getMemento().get(getName(), ""));
 	}
 
 	@Override
 	void persist() {
-		getMemento().put(getName(), this.checkBox.isSelected());
+		getMemento().put(getName(), this.textField.getText());
 	}
 
 }


### PR DESCRIPTION
This PR contains the following field editors:

- Boolean
- Integer
- String
- Color
- Directory

It also implements the "Apply" (Persist) and "Restore Defaults" buttons and corresponding actions. Regarding the Restore Defaults, there is a variation between the current approach in EclipseFX and the way it is done in JFace.

In JFace, the FieldEditor is responsible for loading the Default value from the PreferenceStore (Memento), and the default value is propagated to the store only when "Apply" is pressed. In this PR, the value is reset on the Memento directly, and then the FieldEditor is updated.

We can easily change that; it would simply require a new method on the FieldEditor to restore the defaults. However, since the RestoreDefaults command is Optional in the API, I'm not sure what the initial intent was regarding the responsibility of implementing this action. Should each preference page override it? Or should we provide a generic restore defaults action, and rely on the Memento to provide the correct defaults?