### PR TITLE
Improve backwards compatibility with JFace Preferences:

### DIFF
--- a/demos/org.eclipse.fx.ui.preferences.app/src/org/eclipse/fx/ui/preferences/app/pages/PreferencePageProvider_1.java
+++ b/demos/org.eclipse.fx.ui.preferences.app/src/org/eclipse/fx/ui/preferences/app/pages/PreferencePageProvider_1.java
@@ -12,7 +12,7 @@ import org.eclipse.fx.ui.preferences.page.ColorFieldEditor;
 import org.eclipse.fx.ui.preferences.page.DirectoryFieldEditor;
 import org.eclipse.fx.ui.preferences.page.FieldEditorPreferencePage;
 import org.eclipse.fx.ui.preferences.page.IntegerFieldEditor;
-import org.eclipse.fx.ui.preferences.page.TextFieldEditor;
+import org.eclipse.fx.ui.preferences.page.StringFieldEditor;
 import org.osgi.service.component.annotations.Component;
 
 import javafx.beans.property.ObjectProperty;
@@ -61,7 +61,7 @@ public class PreferencePageProvider_1 implements PreferencePageProvider {
 			addField(new IntegerFieldEditor("integerProperty", "Integer Property"));
 			addField(new ColorFieldEditor("colorProperty", "Color Property"));
 			addField(new DirectoryFieldEditor("directoryProperty", "Directory Property"));
-			addField(new TextFieldEditor("textProperty", "Text"));
+			addField(new StringFieldEditor("textProperty", "Text"));
 		}
 	}
 }

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/DirectoryFieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/DirectoryFieldEditor.java
@@ -20,7 +20,7 @@ import javafx.stage.Window;
 /**
  * <p>A Field editor for directories.</p>
  */
-public class DirectoryFieldEditor extends TextFieldEditor {
+public class DirectoryFieldEditor extends StringFieldEditor {
 
 	public DirectoryFieldEditor(String name, String label) {
 		super(name, label);

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/StringFieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/org/eclipse/fx/ui/preferences/page/StringFieldEditor.java
@@ -17,12 +17,12 @@ import javafx.scene.layout.HBox;
 /**
  * <p>A Field editor for string preferences.</p>
  */
-public class TextFieldEditor extends FieldEditor {
+public class StringFieldEditor extends FieldEditor {
 
 	private HBox textFieldContainer;
 	private TextField textField;
 	
-	public TextFieldEditor(String name, String label) {
+	public StringFieldEditor(String name, String label) {
 		super(name, label);
 		this.textFieldContainer = new HBox();
 		this.textField = new TextField();
@@ -38,7 +38,7 @@ public class TextFieldEditor extends FieldEditor {
 		return this.textField;
 	}
 
-	public TextFieldEditor(String name) {
+	public StringFieldEditor(String name) {
 		this(name, null);
 	}
 


### PR DESCRIPTION
- Change the serialization format of the ColorFieldRenderer, to use the
same persisted string as JFace (With an additional, optional, alpha
value)
- Rename TextFieldEditor to StringFieldEditor

refs #194

Signed-off-by: Camille Letavernier <cletavernier@eclipsesource.com>