### PR TITLE
Improve field editors layout; display the radio group label on top

### DIFF
--- a/modules/ui/org.eclipse.fx.ui.preferences/src/main/java/org/eclipse/fx/ui/preferences/page/FieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/main/java/org/eclipse/fx/ui/preferences/page/FieldEditor.java
@@ -19,6 +19,8 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
+import javafx.geometry.Insets;
+import javafx.scene.Node;
 import javafx.scene.layout.Region;
 
 public abstract class FieldEditor extends Region {
@@ -43,6 +45,23 @@ public abstract class FieldEditor extends Region {
 
 	public FieldEditor(String name) {
 		this(name, null);
+	}
+
+	/**
+	 * <p>
+	 * By default, give all available width and height to the children. If more than
+	 * one child is present in this field editor, subclasses should provide custom
+	 * layout.
+	 * </p>
+	 */
+	@Override
+	protected void layoutChildren() {
+		Insets padding = getPadding();
+		double width = getWidth() - padding.getRight() - padding.getLeft();
+		double height = getHeight() - padding.getTop() - padding.getBottom();
+		for (Node node : getManagedChildren()) {
+			node.resize(width, height);
+		}
 	}
 
 	void setMemento(Memento memento) {
@@ -137,5 +156,20 @@ public abstract class FieldEditor extends Region {
 	 * manage {@link #setDefault(boolean)}
 	 */
 	protected abstract ObservableValue<?> getValue();
+
+	/**
+	 * <p>
+	 * If true, the preference page will be responsible for displaying the label for
+	 * this field editor.
+	 * </p>
+	 * 
+	 * <p>
+	 * Subclasses that need to control how their label should be displayed should
+	 * override this method and return false.
+	 * </p>
+	 */
+	protected boolean displayLabel() {
+		return true;
+	}
 
 }

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/main/java/org/eclipse/fx/ui/preferences/page/FieldEditorPreferencePage.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/main/java/org/eclipse/fx/ui/preferences/page/FieldEditorPreferencePage.java
@@ -146,12 +146,18 @@ public abstract class FieldEditorPreferencePage extends BasePreferencePage {
 	}
 	
 	public void addField(FieldEditor editor) {
-		Label l = new Label();
-		l.textProperty().bind(editor.labelProperty());
-		l.setMinWidth(Region.USE_PREF_SIZE);
+		int editorColumn = 0;
+		int editorSpan = 2;
+		if (editor.displayLabel()) {
+			Label l = new Label();
+			l.textProperty().bind(editor.labelProperty());
+			l.setMinWidth(Region.USE_PREF_SIZE);
+			grid.add(l, 0, editors.size());
+			editorColumn = 1;
+			editorSpan = 1;
+		}
 		
-		grid.add(l, 0, editors.size());
-		grid.add(editor, 1, editors.size());
+		grid.add(editor, editorColumn, editors.size(), editorSpan, 1);
 		GridPane.setHgrow(editor, Priority.ALWAYS);
 		
 		editors.add(editor);

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/main/java/org/eclipse/fx/ui/preferences/page/RadioGroupFieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/main/java/org/eclipse/fx/ui/preferences/page/RadioGroupFieldEditor.java
@@ -14,9 +14,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javafx.beans.value.ObservableValue;
+import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.VBox;
 
 /**
  * <p>
@@ -27,9 +29,14 @@ import javafx.scene.layout.GridPane;
 public class RadioGroupFieldEditor extends FieldEditor {
 	
 	/**
-	 * CSS Style Class for the Grid of this {@link RadioGroupFieldEditor}
+	 * CSS Style Class for the {@link GridPane} of this {@link RadioGroupFieldEditor}
 	 */
 	public static final String RADIO_GRID_STYLE = "radio-field-grid"; //$NON-NLS-1$
+	
+	/**
+	 * CSS Style Class for the RadioGroup Field Editor container ({@link VBox})
+	 */
+	public static final String RADIO_FIELD_STYLE = "radio-field"; //$NON-NLS-1$
 
 	private String currentValue;
 	private Map<String, RadioButton> valueToRadio = new HashMap<>();
@@ -38,6 +45,9 @@ public class RadioGroupFieldEditor extends FieldEditor {
 	public RadioGroupFieldEditor(String name, String label, int numColumns, String[][] labelAndValues) {
 		super(name, label);
 
+		VBox container = new VBox();
+		container.getStyleClass().add(RADIO_FIELD_STYLE);
+		Label l = new Label(label);
 		GridPane grid = new GridPane();
 		grid.getStyleClass().add(RADIO_GRID_STYLE);
 		int column = 0;
@@ -63,7 +73,8 @@ public class RadioGroupFieldEditor extends FieldEditor {
 			}
 		}
 
-		getChildren().add(grid);
+		container.getChildren().addAll(l, grid);
+		getChildren().add(container);
 	}
 
 	@Override
@@ -98,6 +109,11 @@ public class RadioGroupFieldEditor extends FieldEditor {
 	@Override
 	protected ObservableValue<?> getValue() {
 		return this.radioGroup.selectedToggleProperty();
+	}
+	
+	@Override
+	protected boolean displayLabel() {
+		return false;
 	}
 
 }

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/main/java/org/eclipse/fx/ui/preferences/page/StringFieldEditor.java
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/main/java/org/eclipse/fx/ui/preferences/page/StringFieldEditor.java
@@ -14,6 +14,7 @@ package org.eclipse.fx.ui.preferences.page;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 
 /**
  * <p>
@@ -29,14 +30,16 @@ public class StringFieldEditor extends FieldEditor {
 		super(name, label);
 		this.textFieldContainer = new HBox();
 		this.textField = new TextField();
+		this.textField.setMaxWidth(Double.MAX_VALUE);
 		this.textFieldContainer.getChildren().add(textField);
+		HBox.setHgrow(textField, Priority.ALWAYS);
 		getChildren().add(this.textFieldContainer);
 	}
 
 	protected HBox getTextContainer() {
 		return this.textFieldContainer;
 	}
-
+	
 	protected TextField getTextField() {
 		return this.textField;
 	}

--- a/modules/ui/org.eclipse.fx.ui.preferences/src/main/resources/preferenceUI.css
+++ b/modules/ui/org.eclipse.fx.ui.preferences/src/main/resources/preferenceUI.css
@@ -7,6 +7,10 @@
 	-fx-spacing: 5;
 }
 
+.radio-field {
+	-fx-spacing: 5;
+}
+
 .field-editor-grid,
 .radio-field-grid {
 	-fx-hgap: 5;


### PR DESCRIPTION
The field editors now take all the available width in the page. FieldEditors can also display their own label (Instead of the one displayed by default by the FieldEditorPreferencePage), when custom placement is required. This was required to display the RadioGroupFieldEditor's label on top of the radio group

refs #194

Signed-off-by: Camille Letavernier <cletavernier@eclipsesource.com>